### PR TITLE
Replace sojuctl with correct sojudb command

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,7 +30,7 @@ fi
 echo "listen $LISTEN_PROTOCOL://$LISTEN_HOST:$LISTEN_PORT" >> "$CONFIG"
 
 if [ -e "$VOLUME/soju.db" ] || [ \( -z "$DB_TYPE" \) && \( -z "$DB_SOURCE" \) ]); then
-	printf "%s" "$PASSWORD"	| sojuctl -config "$CONFIG" create-user "$ADMIN" -admin
+	printf "%s" "$PASSWORD"	| sojudb -config "$CONFIG" create-user "$ADMIN" -admin
 	if [ -z "$DB_TYPE" ]; then
 		echo "db $DB_TYPE $DB_SOURCE" >> "$CONFIG"
 	else


### PR DESCRIPTION
Hello!

It seems that `sojuctl` is for managing a running instance of IRC (https://codeberg.org/emersion/soju/src/branch/master/doc/sojuctl.1.scd#L5) and currently `sojudb` is used for creating new user. This PR fixes that.

Worth noting is that emersion is most likely moving forges (from sourcehut to codeberg, more about that in the first paragraph [here](https://emersion.fr/blog/2024/status-update-64/)) so there might be a need to update respective links in the future.  